### PR TITLE
Switch video load order since .mov files can be loaded (in a failure …

### DIFF
--- a/src/components/TheTumbler.vue
+++ b/src/components/TheTumbler.vue
@@ -22,8 +22,8 @@
         playsinline
         ref="tumblerVideo"
       >
-        <source :src="require('../assets/tumbler.mov')" type="video/quicktime">
-        <source :src="require('../assets/tumbler.webm')" type="video/webm">
+        <source :src="require('../assets/tumbler.webm')" type="video/webm" />
+        <source :src="require('../assets/tumbler.mov')" type="video/quicktime" />
       </video>
       <audio
         class="tumbler-page-audio"

--- a/vue.config.js
+++ b/vue.config.js
@@ -4,7 +4,6 @@ module.exports = {
   ],
   chainWebpack: config => {
     const rule = config.module.rule('media')
-    console.log(rule)
     rule.store.set('test', /\.(mp4|webm|ogg|mp3|wav|flac|aac|mov)(\?.*)?$/)
   }
 


### PR DESCRIPTION
…manner) by webm-supporting browsers.